### PR TITLE
Support disabling the creation of a ClusterRole and ClusterRoleBinding

### DIFF
--- a/charts/nhi-explorer/templates/clusterrole.yaml
+++ b/charts/nhi-explorer/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clusterRole.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -12,3 +13,4 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list"]
+{{- end }}

--- a/charts/nhi-explorer/templates/clusterrolebinding.yaml
+++ b/charts/nhi-explorer/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.serviceAccount.create .Values.clusterRole.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -13,3 +14,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "nhi-explorer.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/nhi-explorer/tests/clusterrole_test.yaml
+++ b/charts/nhi-explorer/tests/clusterrole_test.yaml
@@ -7,9 +7,17 @@ templates:
 - clusterrole.yaml
 tests:
 - it: "renders the ClusterRole with correct rules"
+  set:
+    clusterRole.create: true
   asserts:
   - isKind:
       of: ClusterRole
   - matchRegex:
       path: metadata.name
       pattern: -nhi-explorer$
+- it: "does not create a ClusterRole"
+  set:
+    clusterRole.create: false
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/nhi-explorer/tests/clusterrolebinding_test.yaml
+++ b/charts/nhi-explorer/tests/clusterrolebinding_test.yaml
@@ -5,8 +5,25 @@ values:
 - ../test_values.yaml
 templates:
 - clusterrolebinding.yaml
+set:
+  clusterRole.create: true
+  serviceAccount.create: true
 tests:
 - it: should have the correct kind for ClusterRoleBinding
   asserts:
   - isAPIVersion:
       of: rbac.authorization.k8s.io/v1
+- it: "does not create a ClusterRoleBinding if clusterRole.create is false"
+  set:
+    clusterRole.create: false
+    serviceAccount.create: true
+  asserts:
+  - hasDocuments:
+      count: 0
+- it: "does not create a ClusterRoleBinding if serviceAccount.create is false"
+  set:
+    clusterRole.create: true
+    serviceAccount.create: false
+  asserts:
+  - hasDocuments:
+      count: 0

--- a/charts/nhi-explorer/values.yaml
+++ b/charts/nhi-explorer/values.yaml
@@ -42,6 +42,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ''
 
+clusterRole:
+  # Specifies whether a clusterRole should be created with permissions to fetch k8s resources
+  create: false
+  name: ''
+
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 podAnnotations: {}


### PR DESCRIPTION
This disables creating the ClusterRole via `values.yml`, and does not create the `ClusterRoleBinding` if a service account or cluster role is not created