### PR TITLE
fix(chart): pass namespace as a value on clusterrolebinding helm template

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then install the explorer, with a values file (examples below):
 helm upgrade explorer gg-nhi/nhi-explorer --install --values values.yml
 ```
 
-An example values file that fetches from HashiCorp Vault:
+An example values file that fetches from HashiCorp Vault and GitLab CI:
 
 ```yaml
 inventory:
@@ -29,6 +29,10 @@ inventory:
         auth_token: "${HASHICORP_VAULT_TOKEN}"
         fetch_all_versions: true
         path: "secret/"
+      gitlabci:
+        type: gitlabci
+        token: "${GITLAB_TOKEN}"
+        url: "https://gitlab.gitguardian.ovh"
     # To upload, set the upload URL and tokens. Ensure the endpoint path ends with /v1
     # This is optional: omit this to prevent uploading and to only test collection.
     upload:

--- a/charts/nhi-explorer/templates/clusterrolebinding.yaml
+++ b/charts/nhi-explorer/templates/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "nhi-explorer.fullname" . }}
-    namespace: default
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "nhi-explorer.fullname" . }}

--- a/charts/nhi-explorer/tests/clusterrolebinding_test.yaml
+++ b/charts/nhi-explorer/tests/clusterrolebinding_test.yaml
@@ -8,11 +8,17 @@ templates:
 set:
   clusterRole.create: true
   serviceAccount.create: true
+  namespace: nhi-explorer
 tests:
 - it: should have the correct kind for ClusterRoleBinding
   asserts:
   - isAPIVersion:
       of: rbac.authorization.k8s.io/v1
+- it: should have the correct namespace
+  asserts:
+  - equal:
+      path: subjects[0].namespace
+      value: nhi-explorer
 - it: "does not create a ClusterRoleBinding if clusterRole.create is false"
   set:
     clusterRole.create: false

--- a/charts/nhi-explorer/values.yaml
+++ b/charts/nhi-explorer/values.yaml
@@ -7,7 +7,7 @@ inventory:
   # Specific version of the image to use
   version: 0.6.1
   # Schedule to run the collection on
-  schedule: '*/15 * * * *'
+  schedule: "*/15 * * * *"
   log_level: info
   # Need to add this explicitly
   config: null
@@ -23,9 +23,8 @@ image:
 # - name: my-secret
 imagePullSecrets: []
 # This is to override the chart name.
-nameOverride: ''
-fullnameOverride: ''
-
+nameOverride: ""
+fullnameOverride: ""
 
 env: []
 envFrom: []
@@ -40,7 +39,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ''
+  name: ""
 
 clusterRole:
   # Specifies whether a clusterRole should be created with permissions to fetch k8s resources
@@ -67,7 +66,6 @@ podSecurityContext: {}
 # runAsUser: 1000
 securityContext: {}
 
-
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -88,3 +86,5 @@ tolerations: []
 affinity: {}
 
 restartPolicy: Never
+
+namespace: default


### PR DESCRIPTION
We need to make the k8s namespace where nhi-explorer is deployed customisable and pass it as a value